### PR TITLE
Add github fetcher

### DIFF
--- a/private/api-runner.rkt
+++ b/private/api-runner.rkt
@@ -6,7 +6,8 @@
          "chunk-list.rkt"
          "logger.rkt"
          "workers/meetup.rkt"
-         "workers/facebook.rkt")
+         "workers/facebook.rkt"
+         "workers/github.rkt")
 
 (provide run-workers)
 
@@ -17,7 +18,8 @@
 
 (define WORKERS
   (hash "meetup" worker-meetup
-        "facebook" worker-facebook))
+        "facebook" worker-facebook
+        "github" worker-github))
 
 ;; How many threads/channels to spin up to do work
 (define THREAD-COUNT 3)

--- a/private/workers/github.rkt
+++ b/private/workers/github.rkt
@@ -1,0 +1,45 @@
+#lang errortrace racket
+
+(require simple-http
+         json
+         (except-in "../hash.rkt" get))
+
+(provide worker-github)
+
+(define api-github
+  ; use raw.githack.com to get correct Content-Type: application/json 
+  (update-ssl (update-host json-requester "raw.githack.com") #t))
+
+;; Workers should respond with either:
+;;
+;; ('ERROR "error message in id") <- try to include id in message
+;; (id jsexpr?)
+
+(define (worker-github logger id config payload)
+  (define id (car payload))
+  (define api-id (get-in '(dataService id) (cdr payload)))
+  (define title (get-in '(title) (cdr payload)))
+
+  ;; Wrap API call with exception handlers that pass errors back up to the
+  ;; worker for logging
+  (with-handlers
+      ([exn:fail:network:http:error?
+        (λ (e)
+          (list 'ERROR (format "Couldn't fetch ~a: ~a"
+                               id (exn:fail:network:http:error-code e))))]
+       [exn:fail:network:http:read?
+        (λ (e)
+          (list 'ERROR (format "Could not read data for ~a: ~a" id e)))])
+
+    (printf  "/~a/master/data/events.json\n" api-id)
+    (define response
+      (get api-github (format "/~a/master/data/events.json" api-id)))
+
+    ;; TODO: remove this
+    ;(printf "remain: ~a | reset: ~a\n" (unbox remaining) (unbox reset))
+
+    ;; Return the converted JSON or an error
+    (let ([json (json-response-body response)])
+         (if (jsexpr? json)
+             (list id json) ;; we need the id for the filename
+             (list 'ERROR (format "Couldn't format ~a into correct JSON" id))))))


### PR DESCRIPTION
  - workflow: users push /data/event.json in the cuttlefish format to their github repo
  - a chapters.json section is added; e.g.:

```json
      "another-city": {
         "dataService": {
              "id": "github-user-id/repo-name",
              "adapter": "github"
          },
          "title": "My City"
       }
```

   e.g. `evacchi/static-test` points to my user repo `static-test`;
   this could often be `papers-we-love/chapter-id`
  - `raw.githubusercontent.com/github-user-id/repo-name/master/data/event.json`
    is fetched and basically used as-is because it is already in the expected format
  - note: this patch is actually using `raw.githack.com` instead of
    `raw.githubusercontent.com` because I could not figure out how to allow
    the text/plain content-type instead of the expected application/json -- because I am a racket n00b

for an example, see https://github.com/evacchi/static-test/