### PR TITLE
Add Eventbrite fetcher

### DIFF
--- a/private/api-runner.rkt
+++ b/private/api-runner.rkt
@@ -6,7 +6,8 @@
          "chunk-list.rkt"
          "logger.rkt"
          "workers/meetup.rkt"
-         "workers/facebook.rkt")
+         "workers/facebook.rkt"
+         "workers/eventbrite.rkt")
 
 (provide run-workers)
 
@@ -17,7 +18,8 @@
 
 (define WORKERS
   (hash "meetup" worker-meetup
-        "facebook" worker-facebook))
+        "facebook" worker-facebook
+        "eventbrite" worker-eventbrite))
 
 ;; How many threads/channels to spin up to do work
 (define THREAD-COUNT 3)

--- a/private/workers/eventbrite.rkt
+++ b/private/workers/eventbrite.rkt
@@ -4,6 +4,7 @@
          gregor
          tzinfo
          simple-http
+         (except-in simple-http JSON-HEADERS)
          json
          (except-in "../hash.rkt" get))
 
@@ -14,7 +15,9 @@
 |#
 
 (define api-eventbrite-com
-    (update-ssl (update-host json-requester "www.eventbriteapi.com") #t))
+    (update-headers 
+      (update-ssl (update-host json-requester "www.eventbriteapi.com") #t)
+    '("Content-Type: text/plain"))) ;; overwrite the application/json editor because of a REST API bug (?)
     
 ;; Mash returned JSON into correct JSEXPR shape
 (define (convert-json json)

--- a/private/workers/eventbrite.rkt
+++ b/private/workers/eventbrite.rkt
@@ -1,0 +1,69 @@
+#lang racket
+
+(require simple-http
+         json
+         (except-in "../hash.rkt" get))
+
+(provide worker-eventbrite)
+
+(define remaining (box #f)) ;; start as false to prevent false throttle
+(define reset (box 0))
+
+(define api-eventbrite-com
+  (update-headers 
+    (update-ssl (update-host json-requester "www.eventbriteapi.com") #t)
+    '("Authorization: Bearer ????API_TOKEN???"))) ;; fixme: get API token from config
+
+
+;; Mash returned JSON into correct JSEXPR shape
+(define (convert-json json)
+  (for/hasheq ([event (get-in '(events) json)])
+    (values (string->symbol (get-in '(id) event))
+            (hasheq 'url (get-in '(link) event)
+                    'time (get-in '(time) event)
+                    'utcOffset (get-in '(utc_offset) event)
+                    'title (get-in '(name) event)
+                    'description (get-in '(description) event)
+                    'venue (hasheq 'name (get-in '(venue name) event 'null)
+                                   'address1 (get-in '(venue address_1) event)
+                                   'address2 (get-in '(venue address_2) event 'null)
+                                   'country (get-in '(venue country) event)
+                                   'city (get-in '(venue city) event)
+                                   'postalCode (get-in '(venue zip) event 'null)
+                                   'lon (get-in '(venue lon) event 'null)
+                                   'lat (get-in '(venue lat) event 'null))
+                    'photos (for/list
+                                ([photo (get-in '(photo_album photo_sample) event '())])
+                              (hasheq 'url (get-in '(photo_link) photo)
+                                      'width 'null
+                                      'height 'null))))))
+
+;; Workers should respond with either:
+;;
+;; ('ERROR "error message in id") <- try to include id in message
+;; (id jsexpr?)
+
+(define (worker-eventbrite logger id config payload)
+  (define id (car payload))
+  (define api-id (get-in '(dataService id) (cdr payload)))
+  (define title (get-in '(title) (cdr payload)))
+
+  ;; Wrap API call with exception handlers that pass errors back up to the
+  ;; worker for logging
+  (with-handlers
+      ([exn:fail:network:http:error?
+        (λ (e)
+          (list 'ERROR (format "Couldn't fetch ~a: ~a"
+                               id (exn:fail:network:http:error-code e))))]
+       [exn:fail:network:http:read?
+        (λ (e)
+          (list 'ERROR (format "Could not read data for ~a" id)))])
+
+    (define response
+      (get api-eventbrite-com (format "/v3/organizations/~a/events/" api-id) )) 
+      
+    ;; Return the converted JSON or an error
+    (let ([json (convert-json (json-response-body response))])
+         (if (jsexpr? json)
+             (list id json) ;; we need the id for the filename
+             (list 'ERROR (format "Couldn't format ~a into correct JSON" id))))))

--- a/private/workers/eventbrite.rkt
+++ b/private/workers/eventbrite.rkt
@@ -36,13 +36,13 @@
                     'title (get-in '(name text) event)
                     'description (get-in '(description html) event)
                     'venue (hasheq 'name (get-in '(venue name) event 'null)
-                                   'address1 (get-in '(venue address_1) event)
-                                   'address2 (get-in '(venue address_2) event 'null)
-                                   'country (get-in '(venue country) event)
-                                   'city (get-in '(venue city) event)
-                                   'postalCode (get-in '(venue zip) event 'null)
-                                   'lon (get-in '(venue lon) event 'null)
-                                   'lat (get-in '(venue lat) event 'null))
+                                   'address1 (get-in '(venue address address_1) event)
+                                   'address2 (get-in '(venue address address_2) event 'null)
+                                   'country (get-in '(venue address country) event)
+                                   'city (get-in '(venue address city) event)
+                                   'postalCode (get-in '(venue address postal_code) event 'null)
+                                   'lon (get-in '(venue longitude) event 'null)
+                                   'lat (get-in '(venue latitude) event 'null))
                     'photos (for/list
                                 ([photo (get-in '(photo_album photo_sample) event '())])
                               (hasheq 'url (get-in '(photo_link) photo)
@@ -60,7 +60,9 @@
   (define title (get-in '(title) (cdr payload)))
 
     (define params
-      `((token . ,(hash-ref config 'eventbrite-access-token))))
+      `(
+        (expand . "venue.address")
+        (token . ,(hash-ref config 'eventbrite-access-token))))
 
   ;; Wrap API call with exception handlers that pass errors back up to the
   ;; worker for logging


### PR DESCRIPTION
Work in progress. ~~Need to figure out how to pull secrets from config and how to convert fields. It's already sort of working if the API key is hardcoded. I can get the short description for the event in the expected format. I fear getting the full description requires doing another fetch. Not sure if it's worth.~~

- requires `eventbrite-access-token` to be set to a valid token in `.cuttlefishrc`
- It's working although I don't have a full example to test yet (we haven't published the venue for our first meeting because reasons). 
- I can confirm that full description requires a full fetch of a different endpoint  
  https://www.eventbrite.it/platform/api#/reference/event/retrieve-an-event 
  >  Note: If the Event being retrieved was created using the new version of Create, then you may notice that the Event’s description field is now being used to hold the event summary. To retrieve your event’s fully-rendered HTML description, you will need to make an additional API call to retrieve the Event's full HTML description.
- responses are ["paginated"](https://www.eventbrite.it/platform/api#/introduction/paginated-responses) it means that a response may not contain all of the events. There are ways to fix this:
    - set `page_size` to a higher number (?) default is 50
    - set `time_filter` to "last N months" or "last year"
    - set `order_by` to `start_desc`

