### PR TITLE
Eventbrite: use millis timestamps

### DIFF
--- a/private/workers/eventbrite.rkt
+++ b/private/workers/eventbrite.rkt
@@ -25,15 +25,15 @@
     (values (string->symbol (get-in '(id) event))
             (hasheq 'url (get-in '(url) event)
                     ;; convert local e.g. '2019-10-24T19:00:00' to posix
-                    ;; timestamp
-                    'time (->posix (iso8601->datetime
-                                    (get-in '(start local) event)))
+                    ;; timestamp, scaling up to millis
+                    'time (* 1000 (->posix (iso8601->datetime
+                                    (get-in '(start local) event))))
                     ;; convert named timezone e.g. 'Europe/Rome' into integer
-                    ;; offset (e.g. 3600)
-                    'utcOffset (tzoffset-utc-seconds
+                    ;; offset (e.g. 3600000)
+                    'utcOffset (* 1000 (tzoffset-utc-seconds
                                 (utc-seconds->tzoffset
                                  (get-in '(start timezone) event)
-                                 0))
+                                 0)))
 
                     'title (get-in '(name text) event)
                     'description (get-in '(description html) event)

--- a/private/workers/eventbrite.rkt
+++ b/private/workers/eventbrite.rkt
@@ -22,19 +22,25 @@
 ;; Mash returned JSON into correct JSEXPR shape
 (define (convert-json json)
   (for/hasheq ([event (get-in '(events) json)])
+
+    ;; convert local e.g. '2019-10-24T19:00:00' to posix
+    (define timestamp (->posix (iso8601->datetime
+                                    (get-in '(start local) event))))
+
+    ;; convert named timezone e.g. 'Europe/Rome' into integer
+    ;; offset including DST (e.g. 3600000)
+    (define utcOffset (* 1000 (tzoffset-utc-seconds
+                          (utc-seconds->tzoffset
+                            (get-in '(start timezone) event)
+                            timestamp))))
+
+    ;; scale up to millis, move to GMT
+    (define utcTimestamp (- (* 1000 timestamp) utcOffset))
+
     (values (string->symbol (get-in '(id) event))
             (hasheq 'url (get-in '(url) event)
-                    ;; convert local e.g. '2019-10-24T19:00:00' to posix
-                    ;; timestamp, scaling up to millis
-                    'time (* 1000 (->posix (iso8601->datetime
-                                    (get-in '(start local) event))))
-                    ;; convert named timezone e.g. 'Europe/Rome' into integer
-                    ;; offset (e.g. 3600000)
-                    'utcOffset (* 1000 (tzoffset-utc-seconds
-                                (utc-seconds->tzoffset
-                                 (get-in '(start timezone) event)
-                                 0)))
-
+                    'time utcTimestamp
+                    'utcOffset utcOffset
                     'title (get-in '(name text) event)
                     'description (get-in '(description html) event)
                     'venue


### PR DESCRIPTION
scale timestamps up to millisecond so that the ruby site generator converts dates correctly