### PR TITLE
fix cuttlefishrc.template, info.rkt

### DIFF
--- a/cuttlefishrc.template
+++ b/cuttlefishrc.template
@@ -1,3 +1,5 @@
-chapter-json-file = /tmp/chapters.json
-json-out-path = /tmp
-logfile-path = /tmp
+{
+    "chapter-json-file": "private/data/chapters.json",
+    "json-out-path": "/tmp/cuttlefish",
+    "logfile-path": "/tmp/cuttlefish"
+}

--- a/info.rkt
+++ b/info.rkt
@@ -6,6 +6,7 @@
                "quickcheck"
                "rackunit-lib"
                "simple-http"
+               "tzinfo"
                "yaml"))
 (define build-deps '("scribble-lib" "racket-doc"))
 (define scribblings '(("scribblings/cuttlefish.scrbl" ())))


### PR DESCRIPTION
- Use the JSON syntax in cuttlefishrc (current syntax is invalid)
- Update info.rkt to include "tzinfo" to avoid a build-time warning
